### PR TITLE
Update Get-PowerSchool_API.ps1 to support all TLS versions

### DIFF
--- a/SDS Scripts/Get-PowerSchool_API.ps1
+++ b/SDS Scripts/Get-PowerSchool_API.ps1
@@ -642,7 +642,7 @@ function Get-Overview
 # Main
 
 &{
-    
+	[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12';
 	$global:AccessToken = Get-AccessToken;
 
     


### PR DESCRIPTION
By default REST API calls made from PowerShell uses TLS v1.0. Some PowerSchool servers require clients to use newer TLS versions. This change allows PowerShell client to declare that it can support TLS versions 1.0, 1.1 and 1.2. SSL3 is mostly not used, but has been kept for backward compat.