### PR TITLE
Initial versions of Add-GroupOwners-To-Teams and Sync-GroupMembership-To-Team

### DIFF
--- a/Teams Scripts/Add-GroupOwners-To-Teams.ps1
+++ b/Teams Scripts/Add-GroupOwners-To-Teams.ps1
@@ -1,0 +1,202 @@
+<#
+.Synopsis
+    Resolves sync issues between Azure Active Directory (AAD) and the Teams internal directory where owners who were present in AAD could not
+    always see the Team.  This script works for SDS created Teams.  The script will find all owners of a Team in AAD and then add those users
+    to the Team directly using the beta/teams/<id>/members Microsoft Graph endpoint.
+
+    Depending on the number of groups SDS has created that have been provisioned, the processing for All SDS teams could take several hours.
+    It is recomended to only process a single teacher's classes instead.
+
+.Requirements
+    Install the Microsoft.Graph.Authentication PowerShell modules, version 0.9.1 or better.
+
+    For machine setup, the PowerShell script may need to be launched in Administrator mode
+
+.Example
+    -For a specific user
+    .\Add-Group-Owners-To-Teams.ps1 -EducatorUPN john.smith@school.edu
+    -For all SDS Teams
+    .\Add-Group-Owners-To-Teams.ps1
+#>
+
+Param (
+    [Parameter(Mandatory = $false)][string]$EducatorUPN)
+
+function Initialize() {
+    import-module Microsoft.Graph.Authentication -MinimumVersion 0.9.1
+    Write-Output "If prompted, please use a tenant admin-account to grant access to 'TeamMember.ReadWrite.All' and 'Group.Read.All' privileges"
+    Refresh-Token
+}
+
+$lastRefreshed = $null
+function Refresh-Token() {
+    if ($lastRefreshed -eq $null -or (get-date - $lastRefreshed).Minutes -gt 29) {
+        connect-graph -scopes TeamMember.ReadWrite.All,Group.Read.All
+        $lastRefreshed = get-date
+    }
+}
+
+# invoke-GraphRequest
+#    -Method POST
+#    -Uri https://graph.microsoft.com/beta/teams/{groupId}/members
+#    -body '{
+#        "@odata.type":"#microsoft.graph.aadUserConversationMember",
+#        "roles":["owner"],
+#        "user@odata.bind":"https://graph.microsoft.com/beta/users/{userId}"
+#        } '
+#    -Headers @{"Content-Type"="application/json"}
+function Add-TeamOwner($groupId, $memberId, $role) {
+    $uri = "https://graph.microsoft.com/beta/teams/$groupId/members"
+    $requestBody = '{
+        "@odata.type":"#microsoft.graph.aadUserConversationMember",
+        "roles":["' + $role +'"],
+        "user@odata.bind":"https://graph.microsoft.com/beta/users(''' + $memberId +''')"
+    }'
+
+    $result = invoke-graphrequest -Method POST -Uri $uri -body $requestBody -ContentType "application/json"
+}
+
+function Refresh-TeamOwners($groupId, $logFilePath) {
+    $TeamOwners = Get-Owners-ForGroup $groupId
+    foreach ($owner in $TeamOwners) {
+        Try {
+            Write-Output "Attempting to add owner $($owner.displayName), $($owner.id)" | Out-File $logFilePath -Append
+
+            Add-TeamOwner $groupId $owner.id "owner"
+
+            Start-Sleep -Seconds 0.5
+        }
+        Catch {
+            $owner.id | Out-File $logFilePath -Append
+            Write-Output ($_.Exception) | Format-List -force | Out-File $logFilePath -Append
+        }
+    }
+}
+
+function Refresh-AllTeamsOwners($SDSTeams, $logFilePath) {
+    $i = 0
+    $processedTeams = @()
+
+    ForEach ($team in $SDSTeams) {
+        Refresh-Token
+        Write-Progress "Processing teams..." -Status "Progress" -PercentComplete (($i / $SDSTeams.count) * 100)
+        Write-Output "Processing team $($team.displayName)" | Out-File $logFilePath -Append
+        try {
+            Refresh-TeamOwners $team.id $logFilePath
+        }
+        catch {
+            Write-Output "Error processing team $($team.displayName)" | Out-File $logFilePath -Append
+            $team.GroupId | Out-File $logFilePath -Append
+            Write-Output ($_.Exception) | Format-List -force | Out-File $logFilePath -Append
+        }
+        $processedTeams = [array]$processedTeams + [array]$team
+
+        $i ++
+    }
+
+    return $processedTeams
+}
+
+# Function "getData" is expected to be of the form:
+# function func($currentUrl) { // Get Graph response; return response }
+# return the data to be aggregate
+function PageAll-GraphRequest($initialUrl, $logFilePath) {
+    $result = @()
+
+    $currentUrl = $initialUrl
+    while ($currentUrl -ne $null) {
+        Refresh-Token
+        $response = invoke-graphrequest -Method GET -Uri $currentUrl -ContentType "application/json"
+        $result += $response.value
+        $currentUrl = $response.'@odata.nextLink'
+    }
+    return $result
+}
+
+$groupSelectClause = "`$select=id,mailNickname,emailAddress,displayName,resourceProvisioningOptions"
+
+function Check-Team($group) {
+    if (($group.resourceProvisioningOptions -ne $null) -and $group.resourceProvisioningOptions.Contains("Team") -and $group.mailNickname.StartsWith("Section_")) {
+        try {
+            Refresh-Token
+            $groupId = $group.id
+            $result = invoke-graphrequest -Method GET -Uri "https://graph.microsoft.com/beta/teams/$groupId/?`$select=id" -ContentType "application/json" -SkipHttpErrorCheck
+            return ($result -ne $null -and (-Not $result.ContainsKey("error")))
+        }
+        catch {
+            return $false
+        }
+    }
+}
+
+function Get-SDSTeams($logFilePath) {
+    $initialSDSGroupUri = "https://graph.microsoft.com/beta/groups?`$filter=groupTypes/any(c:c+eq+'Unified')+and+startswith(mailNickname,'Section_')+and+resourceProvisioningOptions/Any(x:x+eq+'Team')&$groupSelectClause"
+    $unfilteredSDSGroups = PageAll-GraphRequest $initialSDSGroupUri $logFilePath
+    write-output "Retrieve $($unfilteredSDSGroups.Count) groups." | out-file $logFilePath -Append
+    $filteredSDSTeams = $unfilteredSDSGroups | Where-Object { Check-Team $_ }
+    write-output "Filtered to $($filteredSDSTeams.Count) groups." | out-file $logFilePath -Append
+    return $filteredSDSTeams
+}
+
+function Get-SDSTeams-ForUser($EducatorUPN, $logFilePath) {
+    $initialOwnedObjectsUri = "https://graph.microsoft.com/beta/user/$EducatorUPN/ownedObjects?$groupSelectClause"
+    $unfilteredOwnedGroups = PageAll-GraphRequest $initialOwnedObjectsUri $logFilePath
+    $filteredOwnedGroups =  $unfilteredOwnedGroups | Where-Object { Check-Team $_}
+    return $filteredOwnedGroups
+}
+
+function Get-Owners-ForGroup($groupId) {
+    $initialOwnersUri = "https://graph.microsoft.com/beta/groups/$groupId/owners"
+    $unfilteredOwners = PageAll-GraphRequest $initialOwnersUri $logFilePath
+    $filteredOwners = $unfilteredOwners | Where-Object { $_."@odata.type" -eq "#microsoft.graph.user" }
+    return $filteredOwners
+}
+
+function Execute($EducatorUPN, $recordedGroups, $logFilePath) {
+    $processedTeams = $null
+
+    Initialize
+    
+    if ($EducatorUPN -eq "") {
+        Write-Output "Obtaining list of SDS Created Teams. Please wait..."
+
+        $SDSTeams = Get-SDSTeams $logFilePath
+
+        Write-Output "Identified $($SDSTeams.count) teams that are provisioned." | Out-File $logFilePath -Append
+
+        # Process Removal and addition of all team owners
+
+        Write-Output "Processing addition of all owners for $($SDSTeams.count) Teams, please wait as this could take several hours..." | Out-File $logFilePath -Append
+
+        $processedTeams = Refresh-AllTeamsOwners $SDSTeams $logFilePath
+    }
+    else {
+        Write-Output "Obtaining list of SDS Teams for user $($EducatorUPN), Please wait..." | Out-File $logFilePath -Append
+        $SDSTeams = Get-SDSTeams-ForUser $EducatorUPN $logFilePath
+
+        Write-Output "Identified $($SDSTeams.count) teams that are provisioned." | Out-File $logFilePath -Append
+
+        # Process addition of all team owners
+
+        Write-Output "Processing addition of all owners for $($SDSTeams.count) Teams, please wait as this could take several hours..." | Out-File $logFilePath -Append
+
+        $processedTeams = Refresh-AllTeamsOwners $SDSTeams $logFilePath
+    }
+
+    $processedTeams | Export-Csv -Path $recordedGroups -NoTypeInformation
+
+    Write-Output "Script Complete." | Out-File $logFilePath -Append
+}
+
+$logFilePath = ".\Add-Group-Owners-To-Teams.log"
+$recordedGroups = ".\Updated-Teams.csv"
+
+try {
+    Execute $EducatorUPN $recordedGroups $logFilePath
+}
+catch {
+    Write-Error "Terminal Error occurred in processing."
+    Write-output "Terminal error: exception: $($_.Exception)" | out-file $logFilePath -append
+}
+
+Write-Output "Please run 'disconnect-graph' if you are finished making changes."

--- a/Teams Scripts/Sync-GroupMembership-To-Team.ps1
+++ b/Teams Scripts/Sync-GroupMembership-To-Team.ps1
@@ -1,0 +1,212 @@
+<#
+.Synopsis
+    If Teachers/Students do not appear in a Team but the memberships are correct in Azure Active Directory, this script will make sure that the Team memberships matches AAD.
+
+    This script can be run by giving it one identifier of the Team/Group that should have memberships synced:
+        o	SIS ID - of the Section
+        o	Mail Nickname of the AAD Group 
+        o	Email Address of the AAD Group 
+        o	Group ID of the AAD Group
+
+.Requirements
+    Install the Microsoft.Graph.Authentication PowerShell modules, version 0.9.1 or better.
+
+    For machine setup, the PowerShell script may need to be launched in Administrator mode
+
+.Example
+    -For a given SIS Id:
+    .\Sync-GroupMembership-To-Team.ps1 -sisId "008200123"
+    -For a given mailNickname:
+    .\Sync-GroupMembership-To-Team.ps1 -mailNickname "Section_008200123"
+    -For a given emailAddress:
+    .\Sync-GroupMembership-To-Team.ps1 -emailAddress "Section_008200123@demoschool.onmicrosoft.com"
+    -For a given groupId:
+    .\Sync-GroupMembership-To-Team.ps1 -groupId "e77144f7-a42c-4124-856e-bf6312a5ed2f"
+#>
+
+Param (
+    [Parameter(Mandatory = $false)][string]$sisId,
+    [Parameter(Mandatory = $false)][string]$emailAddress,
+    [Parameter(Mandatory = $false)][string]$mailNickname,
+    [Parameter(Mandatory = $false)][string]$groupId)
+
+function Initialize() {
+    import-module Microsoft.Graph.Authentication -MinimumVersion 0.9.1
+    Write-Output "If prompted, please use a tenant admin-account to grant access to 'TeamMember.ReadWrite.All' and 'Group.Read.All' privileges"
+    connect-graph -scopes TeamMember.ReadWrite.All,Group.Read.All
+}
+
+# invoke-GraphRequest
+#    -Method POST
+#    -Uri https://graph.microsoft.com/beta/teams/{groupId}/members
+#    -body '{
+#        "@odata.type":"#microsoft.graph.aadUserConversationMember",
+#        "roles":["owner"],
+#        "user@odata.bind":"https://graph.microsoft.com/beta/users/{userId}"
+#        } '
+#    -Headers @{"Content-Type"="application/json"}
+function Add-TeamUser($groupId, $memberId, $role) {
+    $uri = "https://graph.microsoft.com/beta/teams/$groupId/members"
+    $requestBody = '{
+        "@odata.type":"#microsoft.graph.aadUserConversationMember",
+        "roles":["' + $role +'"],
+        "user@odata.bind":"https://graph.microsoft.com/beta/users(''' + $memberId +''')"
+    }'
+
+    $result = invoke-graphrequest -Method POST -Uri $uri -body $requestBody -ContentType "application/json"
+}
+
+function Remove-OwnersFromMembers($members, $groupOwners) {
+    $groupOwnersById = @{}
+    $groupOwners | % {$groupOwnersById.Add($_.id, $_)}
+    $filteredMembers = $members | ? {-not $groupOwnersById.ContainsKey($_.id)}
+    return $filteredMembers
+}
+
+function Refresh-TeamMembers($groupId, $groupOwners, $logFilePath) {
+    $members = Get-Members-ForGroup $groupId
+    $filteredMembers = Remove-OwnersFromMembers $members $groupOwners
+    Write-output "Processing $($filteredMembers.Count) members."
+    Refresh-TeamUsers $groupId $filteredMembers "member" $logFilePath
+}
+
+function Set-TeamOwners($groupId, $groupOwners, $logFilePath) {
+    Refresh-TeamUsers $groupId $groupOwners "owner" $logFilePath
+}
+
+function Refresh-TeamUsers($groupId, $users, $role, $logFilePath) {
+    foreach ($user in $users) {
+        Try {
+            Write-Output "Attempting to add $role $($user.displayName), $($user.id)" | Out-File $logFilePath -Append
+
+            Add-TeamUser $groupId $user.id $role
+
+            Start-Sleep -Seconds 0.5
+        }
+        Catch {
+            $user.id | Out-File $logFilePath -Append
+            Write-Output ($_.Exception) | Format-List -force | Out-File $logFilePath -Append
+        }
+    }
+}
+
+# Function "getData" is expected to be of the form:
+# function func($currentUrl) { // Get Graph response; return response }
+# return the data to be aggregate
+function PageAll-GraphRequest($initialUrl, $logFilePath) {
+    $result = @()
+
+    $currentUrl = $initialUrl
+
+    while ($currentUrl -ne $null) {
+        $response = invoke-graphrequest -Method GET -Uri $currentUrl -ContentType "application/json"
+        $result += $response.value
+        $currentUrl = $response.'@odata.nextLink'
+    }
+    return $result
+}
+
+$groupSelectClause = "`$select=id,mailNickname,emailAddress,displayName,resourceProvisioningOptions"
+
+function Get-TeamByGroupId($groupId) {
+    $result = invoke-graphrequest -Method GET -Uri "https://graph.microsoft.com/beta/teams/$groupId/?`$select=id,isMembershipLimitedToOwners" -ContentType "application/json" -SkipHttpErrorCheck
+    return $result
+}
+
+function Check-IsTeamFromResult($teamResult) {
+    return ($teamResult -ne $null -and (-Not $teamResult.ContainsKey("error")))
+}
+
+function Check-IsTeamUnlocked($teamResult) {
+    return -not $teamResult.isMembershipLimitedToOwners
+}
+
+function Get-Owners-ForGroup($groupId) {
+    $initialOwnersUri = "https://graph.microsoft.com/beta/groups/$groupId/owners"
+    $unfilteredOwners = PageAll-GraphRequest $initialOwnersUri $logFilePath
+    $filteredOwners = $unfilteredOwners | Where-Object { $_."@odata.type" -eq "#microsoft.graph.user" }
+    return $filteredOwners
+}
+
+function Get-Members-ForGroup($groupId) {
+    $initialMembersUri = "https://graph.microsoft.com/beta/groups/$groupId/members"
+    $unfilteredMembers = PageAll-GraphRequest $initialMembersUri $logFilePath
+    $filteredMembers = $unfilteredMembers | Where-Object { $_."@odata.type" -eq "#microsoft.graph.user" }
+    return $filteredMembers
+}
+
+function Get-SingleObjectId($uri) {
+    $result = invoke-graphrequest -method GET -Uri $searchResultUri -ContentType "application/json"
+    return $result.value[0].id
+}
+
+function Get-GroupIdForSisId($sisId) {
+    return Get-GroupIdForMailNickname("Section_$sisId")
+}
+
+function Get-GroupIdForEmailAddress($emailAddress) {
+    $searchResultUri = "https://graph.microsoft.com/beta/groups/?`$filter=mail+eq+'$emailAddress'&$groupSelectClause"
+    return Get-SingleObjectId $searchResultUri
+}
+
+function Get-GroupIdForMailNickname($mailNickname) {
+    $searchResultUri = "https://graph.microsoft.com/beta/groups/?`$filter=mailNickName+eq+'$mailNickname'&$groupSelectClause"
+    return Get-SingleObjectId $searchResultUri
+}
+
+function Execute($sisId, $emailAddress, $mailNickname, $groupId, $logFilePath) {
+    $processedTeams = $null
+
+    Initialize
+
+    if ($groupId -eq "") {
+        if ($sisId -ne "") {
+            $groupId = Get-GroupIdForSisId $sisId
+        }
+        elseif ($emailAddress -ne "") {
+            $groupId = Get-GroupIdForEmailAddress $emailAddress
+        }
+        elseif ($mailNickname -ne "") {
+            $groupId = Get-GroupIdForMailNickname $mailNickname
+        }
+    }
+
+    $teamResult = Get-TeamByGroupId $groupId
+
+    if (-not (Check-IsTeamFromResult $teamResult)) {
+        write-error "Specified group $groupId is not a Team"
+        exit
+    }
+    Write-output "Processing '$($teamResult.displayName).'"
+
+    Write-output "Retrieving group owners."
+    $groupOwners = Get-Owners-ForGroup $groupId
+    Write-output "Processing $($groupOwners.Count) owners."
+    Set-TeamOwners $groupId $groupOwners $logFilePath
+
+    if (Check-IsTeamUnlocked $teamResult) {
+        Refresh-TeamMembers $groupId $groupOwners $logFilePath
+    }
+    else {
+        Write-Output "Team $($team.displayName) is not unlocked; only owners have been synchronized."
+    }
+    
+    Write-Output "Script Complete."
+}
+
+$logFilePath = ".\Sync-GroupMembership-To-Team.log"
+
+if ($sisId -eq "" -and $emailAddress -eq "" -and $mailNickname -eq "" -and $groupId -eq "") {
+    Write-Error "One of -sisId, -emailAddress, -mailNickname, or -groupId must be specified."
+    exit
+}
+
+try {
+    Execute $sisId $emailAddress $mailNickname $groupId $logFilePath
+}
+catch {
+    Write-Error "Terminal Error occurred in processing."
+    Write-output "Terminal error: exception: $($_.Exception)" | out-file $logFilePath -append
+}
+
+Write-Output "Please run 'disconnect-graph' if you are finished making changes."


### PR DESCRIPTION
Back to School traffic has uncovered some issues in how SDS's interactions with AAD are "interpreted" by Teams.

In order to mitigate these issues, here are two helper scripts:
- Add-GroupOwners-To-Teams: This script reads the Group Owners from AAD, and force-adds each of them as owner to that Team. This API is in beta, and is rate controlled -- but does not require removing or readding to the Group, and succeeds or fails immediately. This script can run against a single user account, and processes all SDS-created-Groups-that-are-Teams that user owns. This script can also run across an entire tenant, processing all SDS Teams. This will take time -- minutes to retrieve the list of Groups, verify whether the Sections are actually Teams, then querying owners and adding them "back."
- Sync-GroupMembership-To-Team: This script reads the entire ownership and membership list from an AAD group, and immediately forces them to Teams. If the group is still Locked (i..e., not Activated), only the Ownership is synced -- the membership will be synced on Activation. This averts the 24-48 hour maximum latency in synchronizing AAD group membership and Teams.