### PR TITLE
Script fails to read group members

### DIFF
--- a/Teams Scripts/Add-GroupOwners-To-Teams.ps1
+++ b/Teams Scripts/Add-GroupOwners-To-Teams.ps1
@@ -24,14 +24,14 @@ Param (
 
 function Initialize() {
     import-module Microsoft.Graph.Authentication -MinimumVersion 0.9.1
-    Write-Output "If prompted, please use a tenant admin-account to grant access to 'TeamMember.ReadWrite.All' and 'Group.Read.All' privileges"
+    Write-Output "If prompted, please use a tenant admin-account to grant access to 'TeamMember.ReadWrite.All', 'Group.Read.All' and 'Directory.AccessAsUser.All' privileges"
     Refresh-Token
 }
 
 $lastRefreshed = $null
 function Refresh-Token() {
     if ($lastRefreshed -eq $null -or (get-date - $lastRefreshed).Minutes -gt 10) {
-        connect-graph -scopes TeamMember.ReadWrite.All,Group.Read.All
+        connect-graph -scopes TeamMember.ReadWrite.All,Group.Read.All,Directory.AccessAsUser.All
         $lastRefreshed = get-date
     }
 }

--- a/Teams Scripts/Sync-GroupMembership-To-Team.ps1
+++ b/Teams Scripts/Sync-GroupMembership-To-Team.ps1
@@ -32,8 +32,8 @@ Param (
 
 function Initialize() {
     import-module Microsoft.Graph.Authentication -MinimumVersion 0.9.1
-    Write-Output "If prompted, please use a tenant admin-account to grant access to 'TeamMember.ReadWrite.All' and 'Group.Read.All' privileges"
-    connect-graph -scopes TeamMember.ReadWrite.All,Group.Read.All
+    Write-Output "If prompted, please use a tenant admin-account to grant access to 'TeamMember.ReadWrite.All', 'Group.Read.All' and 'Directory.AccessAsUser.All' privileges"
+    connect-graph -scopes TeamMember.ReadWrite.All,Group.Read.All,Directory.AccessAsUser.All
 }
 
 # invoke-GraphRequest

--- a/Teams Scripts/Sync-GroupMembership-To-Team.ps1
+++ b/Teams Scripts/Sync-GroupMembership-To-Team.ps1
@@ -121,7 +121,7 @@ function PageAll-GraphRequest($initialUrl, $logFilePath) {
 $groupSelectClause = "`$select=id,mailNickname,emailAddress,displayName,resourceProvisioningOptions"
 
 function Get-TeamByGroupId($groupId) {
-    $result = invoke-graphrequest -Method GET -Uri "https://graph.microsoft.com/beta/teams/$groupId/?`$select=id,isMembershipLimitedToOwners" -ContentType "application/json" -SkipHttpErrorCheck
+    $result = invoke-graphrequest -Method GET -Uri "https://graph.microsoft.com/beta/teams/$groupId/?`$select=id,isMembershipLimitedToOwners,displayName" -ContentType "application/json" -SkipHttpErrorCheck
     return $result
 }
 


### PR DESCRIPTION
The new ``Sync-GroupMembeship-To-Team`` and ``Add-GroupOwners-To-Teams`` scripts is unable to access information about members in O365 groups, and therefore fails to run.

When running the sync script, it's returning this error when syncing a Team that is activated (because calls to ``https://graph.microsoft.com/beta/groups/<group-id>/members`` returns an empty value array):

![image](https://user-images.githubusercontent.com/13292913/90312346-05e55400-df04-11ea-8665-9276bd926627.png)

Please also note that the group name is empty, adding the 'displayName' property to the graph selection, fixes this.

Adding the scope ``Directory.AccessAsUser.All`` to the graph token, seems to fix the issue:

![image](https://user-images.githubusercontent.com/13292913/90312318-c74f9980-df03-11ea-8adc-45372e8c84ff.png)