### PR TITLE
Reorder assignment in Block-PowerShell_for_everyone_except_me.ps1

### DIFF
--- a/SDS Scripts/Block PowerShell/Block-PowerShell_for_everyone_except_me.ps1
+++ b/SDS Scripts/Block PowerShell/Block-PowerShell_for_everyone_except_me.ps1
@@ -15,11 +15,11 @@ if (-not $sp) {
     $sp = New-AzureADServicePrincipal -AppId $appId
 }
 
-# Require user assignment for the Graph app
-Set-AzureADServicePrincipal -ObjectId $sp.ObjectId -AppRoleAssignmentRequired $true
-
 # Assign the default app role (0-Guid) to the current user
 $me = Get-AzureADUser -ObjectId $session.Account.Id
 New-AzureADServiceAppRoleAssignment -ObjectId $sp.ObjectId -ResourceId $sp.ObjectId -Id ([Guid]::Empty.ToString()) -PrincipalId $me.ObjectId
+
+# Require user assignment for the Graph app
+Set-AzureADServicePrincipal -ObjectId $sp.ObjectId -AppRoleAssignmentRequired $true
 
 Write-host "Script Complete. PowerShell is now restricted."


### PR DESCRIPTION
Assigning the user before requiring assignment

### Related Issue
N/A

### Summary
Assigning the user before requiring assignment

### Reason
If someone were to run this line by line, by requiring assignment first, they wouldn't be able to assign themselves after requiring assignment, since they would be limited pshell access to only assigned users from the step before.

### Proposed Change(s)
- Move assign user before requiring assignment

### Details
- Made requested change

### Additional Info
n/a

### References
n/a

### Checklist
n/a